### PR TITLE
fix(symmetry): use reciprocal action for MSG little groups

### DIFF
--- a/src/findspingroup/find_spin_group.py
+++ b/src/findspingroup/find_spin_group.py
@@ -5677,7 +5677,8 @@ def _get_magnetic_little_group(kpoint, primitive_msg_operations, tol: float) -> 
     magnetic_little_group = []
     primitive_kpoint = np.asarray(kpoint, dtype=float)
     for time_reversal, rotation, translation in primitive_msg_operations:
-        transformed_kpoint = time_reversal * np.asarray(rotation, dtype=float) @ primitive_kpoint
+        reciprocal_rotation = np.linalg.inv(np.asarray(rotation, dtype=float)).T
+        transformed_kpoint = time_reversal * reciprocal_rotation @ primitive_kpoint
         if getNormInf(transformed_kpoint % 1, primitive_kpoint) < tol:
             magnetic_little_group.append([time_reversal, rotation, translation])
     return magnetic_little_group

--- a/tests/test_find_spin_group.py
+++ b/tests/test_find_spin_group.py
@@ -3500,6 +3500,22 @@ def test_find_spin_group_recovers_msg_little_group_symbols_after_translation_cle
     assert "Unknown" not in set(result.msg_little_group_symbols)
 
 
+def test_msg_little_group_uses_reciprocal_rotation_for_centered_primitive_basis():
+    result = find_spin_group(
+        "tests/testset/mcif_241130_no2186/0.236_CaFe4Al8.mcif",
+        mtol=0.002,
+    )
+
+    assert result.msg_bns_number == "139.535"
+    assert result.msg_little_group_symbols[:5] == [
+        "4'/mmm'",
+        "4'/mmm'",
+        "4'22'",
+        "m'm'm",
+        "2/m",
+    ]
+
+
 def test_find_spin_group_keeps_maximal_ssg_when_ossg_msg_little_group_is_unindexed():
     result = find_spin_group(
         "tests/testset/mcif_241130_no2186/1.85_alpha-Mn.mcif",


### PR DESCRIPTION
## Summary
- Fix MSG little-group k-point matching to use reciprocal-space action `R^{-T}` instead of real-space fractional action `R`.
- Add a regression test for the centered primitive basis case exposed by GitHub issue #18.
- Preserve existing SSG/GSPG little-group behavior, which already used reciprocal action.

## Motivation
GitHub issue #18 reports that MSG co-little group symbols are underestimated for centered primitive settings, e.g. `0.236_CaFe4Al8` with MSG `I4'/mmm' (139.535)`. The previous MSG path applied real-space fractional rotations directly to reciprocal k vectors. This is only valid in special orthogonal settings and fails in primitive bases for centered lattices.

## Main changes
- Update `_get_magnetic_little_group()` to transform reciprocal fractional k vectors with `time_reversal * inv(rotation).T`.
- Add a regression test asserting the corrected GM/M/P/X/N MSG little-group symbols for `0.236_CaFe4Al8`.

## Testing
- `pytest tests/test_find_spin_group.py -q`
  - `327 passed`
- `pytest tests/test_poscar_parser.py tests/test_scif_parser.py tests/test_export_mcif_results.py -q`
  - `81 passed`
- 2241 full batch on a016:
  - `2241/2241` processed
  - `2241` success
  - `0` errors
  - `0` mismatches

Manual field-level comparison against the previous 2241 full run shows no drift in core identification, KPOINTS, SSG little groups, spin texture configs, tensor outputs, magnetic-site summary, vector constraints, polar axes, or operation views. Changes are limited to MSG k-resolved little-group fields and their derived MSG spin polarizations.

## Risk / compatibility
This intentionally changes public MSG k-resolved outputs:
- `msg_little_group_symbols`
- `msg_little_group_ops`
- `msg_little_group_seitz_latex`
- `msg_spin_polarizations`

The change is a correction to reciprocal-space symmetry semantics and may require downstream UI/export baselines to accept the updated MSG little-group values.

## Related issues
Closes #18.
