### PR TITLE
fix(spin-texture): make basis remainder formatting idempotent

### DIFF
--- a/src/findspingroup/data/acc_aligned_p_index_loader.py
+++ b/src/findspingroup/data/acc_aligned_p_index_loader.py
@@ -87,17 +87,13 @@ def _spin_texture_config_record(payload: dict) -> dict:
     basis = record.get("basis")
     order = record.get("order")
     remainder_order = int(order) if order is not None else None
-    if basis and not any(" + o(" in str(expression) for expression in basis):
+    if basis:
         basis = combine_spin_texture_basis(basis)
         record["basis"] = _append_basis_remainder_ascii(basis, remainder_order)
-        basis_latex = spin_texture_basis_latex(basis)
+        basis_latex = spin_texture_basis_latex(record["basis"])
         record["basis_latex"] = _append_basis_remainder_latex(basis_latex, remainder_order)
     else:
-        if basis:
-            record["basis"] = combine_spin_texture_basis(basis)
-            record["basis_latex"] = spin_texture_basis_latex(record["basis"])
-        else:
-            record.setdefault("basis_latex", spin_texture_basis_latex(record.get("basis")))
+        record.setdefault("basis_latex", spin_texture_basis_latex(record.get("basis")))
     return record
 
 

--- a/src/findspingroup/spin_splitting.py
+++ b/src/findspingroup/spin_splitting.py
@@ -212,10 +212,18 @@ def _split_signed_terms(text: str) -> list[tuple[int, str]]:
 
 def _split_basis_remainder_suffix(text: str) -> tuple[str, str]:
     marker = " + o("
-    index = text.rfind(marker)
-    if index < 0:
-        return text, ""
-    return text[:index], text[index:]
+    text = str(text).strip()
+    suffix = ""
+    while True:
+        index = text.rfind(marker)
+        if index < 0:
+            return text, suffix
+        candidate_suffix = text[index:]
+        if not candidate_suffix.endswith(")"):
+            return text, suffix
+        if not suffix:
+            suffix = candidate_suffix
+        text = text[:index].rstrip()
 
 
 def _basis_remainder_suffix_to_latex(suffix: str) -> str:
@@ -413,10 +421,14 @@ def _basis_remainder_latex(order: int) -> str:
 def _append_basis_remainder_ascii(basis: Sequence[str] | None, order: int | None) -> list[str]:
     if not basis:
         return []
+    normalized_basis = [combine_spin_texture_basis_expression(str(expression)) for expression in basis]
     if order is None:
-        return [str(expression) for expression in basis]
+        return normalized_basis
     suffix = _basis_remainder_ascii(int(order))
-    return [f"{expression} + {suffix}" for expression in basis]
+    return [
+        f"{_split_basis_remainder_suffix(expression)[0]} + {suffix}"
+        for expression in normalized_basis
+    ]
 
 
 def _append_basis_remainder_latex(basis_latex: Sequence[str] | None, order: int | None) -> list[str]:
@@ -425,7 +437,10 @@ def _append_basis_remainder_latex(basis_latex: Sequence[str] | None, order: int 
     if order is None:
         return [str(expression) for expression in basis_latex]
     suffix = _basis_remainder_latex(int(order))
-    return [rf"{expression} + {suffix}" for expression in basis_latex]
+    return [
+        rf"{_split_basis_remainder_suffix(str(expression))[0]} + {suffix}"
+        for expression in basis_latex
+    ]
 
 
 def _resolve_basis_remainder_order(

--- a/tests/test_find_spin_group.py
+++ b/tests/test_find_spin_group.py
@@ -12,6 +12,7 @@ import findspingroup.core.identify_spin_space_group as identify_spin_space_group
 import findspingroup.structure.cell as cell_module
 import findspingroup.structure.group as group_module
 from findspingroup.data.acc_aligned_p_index_loader import (
+    _spin_texture_config_record,
     get_pair_id_for_ssg_label,
     get_ssg_conventional_kpoint_symbols_for_label,
     get_spin_texture_config_for_ssg_label,
@@ -29,11 +30,14 @@ from findspingroup import (
 )
 from findspingroup.find_spin_group import _expand_magnetic_indices_by_sg_orbit
 from findspingroup.spin_splitting import (
+    _append_basis_remainder_ascii,
+    _append_basis_remainder_latex,
     basis_expression_to_latex,
     canonicalize_nullspace,
     classify_public_spin_texture_config,
     combine_spin_texture_basis_expression,
     operation_pairs_from_gspg_ops,
+    spin_texture_basis_latex,
 )
 from findspingroup.core.identify_index.functions import (
     find_stand_gen_maps,
@@ -5695,6 +5699,51 @@ def test_spin_texture_basis_expression_latex_formatter():
         r"C_{1}\left(\left(-\frac{2}{3}k_{y}^{3} + "
         r"k_{x}k_{y}^{2}\right)\,\sigma_{z}\right)"
     )
+    suffixed_expression = (
+        "C1*((kx*ky)*sigma_x + (ky*kz)*sigma_x) + o(k^2) + o(k^2)"
+    )
+    assert combine_spin_texture_basis_expression(suffixed_expression) == (
+        "C1*((kx*ky + ky*kz)*sigma_x) + o(k^2)"
+    )
+    assert _append_basis_remainder_ascii([suffixed_expression], 2) == [
+        "C1*((kx*ky + ky*kz)*sigma_x) + o(k^2)"
+    ]
+    assert _append_basis_remainder_ascii(
+        ["C1*((kx*ky)*sigma_x + (ky*kz)*sigma_x) + o(k)"],
+        2,
+    ) == ["C1*((kx*ky + ky*kz)*sigma_x) + o(k^2)"]
+    suffixed_latex = spin_texture_basis_latex([suffixed_expression])
+    assert _append_basis_remainder_latex(suffixed_latex, 2) == [
+        r"C_{1}\left(\left(k_{x}k_{y} + k_{y}k_{z}\right)\,\sigma_{x}\right) + o(k^{2})"
+    ]
+    assert _append_basis_remainder_latex(
+        [
+            r"C_{1}\left(\left(k_{x}k_{y} + k_{y}k_{z}\right)\,\sigma_{x}\right) + o(k)"
+        ],
+        2,
+    ) == [
+        r"C_{1}\left(\left(k_{x}k_{y} + k_{y}k_{z}\right)\,\sigma_{x}\right) + o(k^{2})"
+    ]
+
+
+def test_spin_texture_runtime_record_keeps_single_remainder_after_grouping():
+    record = _spin_texture_config_record(
+        {
+            "spin_texture_type": "d-wave",
+            "momentum_space_spin_configuration": "collinear",
+            "spin_rank": 1,
+            "nullity": 1,
+            "order": 2,
+            "basis": [
+                "C1*((kx*ky)*sigma_x + (ky*kz)*sigma_x) + o(k^2)",
+            ],
+        }
+    )
+
+    assert record["basis"] == ["C1*((kx*ky + ky*kz)*sigma_x) + o(k^2)"]
+    assert record["basis_latex"] == [
+        r"C_{1}\left(\left(k_{x}k_{y} + k_{y}k_{z}\right)\,\sigma_{x}\right) + o(k^{2})"
+    ]
 
 
 def test_spin_texture_canonical_nullspace_does_not_amplify_near_zero_pivots():


### PR DESCRIPTION
## Summary
- Make spin texture basis remainder formatting idempotent.
- Normalize runtime-index spin texture records through the same formatter path.
- Add regression coverage for grouped sigma terms and duplicate `o(k^n)` suffixes.
