### PR TITLE
feat(api): identify spin space groups from operations

### DIFF
--- a/examples/spin_space_group_from_operations.py
+++ b/examples/spin_space_group_from_operations.py
@@ -1,0 +1,258 @@
+"""Identify spin space groups directly from operation generators.
+
+Run from the repository root with:
+
+    PYTHONPATH=src python examples/spin_space_group_from_operations.py
+
+There is no implicit real-space convention in the operation-input API. Each
+example names the setting used by its real rotations and translations. The
+default is ``spin_frame="cartesian"`` and requires a lattice or metric.
+Examples whose spin matrices are already written in an oriented setting say so
+explicitly.
+
+Translations are already reduced componentwise to the required [0, 1) range.
+"""
+
+from math import sqrt
+
+from findspingroup import get_spin_space_group_from_operations
+
+
+IDENTITY = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+MINUS_IDENTITY = [[-1, 0, 0], [0, -1, 0], [0, 0, -1]]
+C3_ORIENTED = [[0, -1, 0], [1, -1, 0], [0, 0, 1]]
+MN3SN_CONVENTION_LATTICE = [
+    [5.665, 0, 0],
+    [-2.8325, 4.906033912438845, 0],
+    [0, 0, 4.531],
+]
+MN3SN_MAGNETIC_PRIMITIVE_LATTICE = [
+    [-5.665, 0, 0],
+    [2.8325, -4.906033912438845, 0],
+    [0, 0, 4.531],
+]
+
+
+def _mn3sn_nssg_generators():
+    """Return the four non-spin-only Mn3Sn generators."""
+    # 0.200_Mn3Sn, convention-oriented operation rows 3, 9, 15, and 20.
+    return [
+        {
+            "spin_rotation": C3_ORIENTED,
+            "real_rotation": [[1, -1, 0], [1, 0, 0], [0, 0, 1]],
+            "translation": [0, 0, 0.5],
+        },
+        {
+            "spin_rotation": IDENTITY,
+            "real_rotation": [[1, 0, 0], [0, 1, 0], [0, 0, -1]],
+            "translation": [0, 0, 0.5],
+        },
+        {
+            "spin_rotation": [[0, -1, 0], [-1, 0, 0], [0, 0, -1]],
+            "real_rotation": [[-1, 1, 0], [0, 1, 0], [0, 0, 1]],
+            "translation": [0, 0, 0],
+        },
+        {
+            "spin_rotation": [[1, 0, 0], [1, -1, 0], [0, 0, -1]],
+            "real_rotation": [[-1, 0, 0], [-1, 1, 0], [0, 0, 1]],
+            "translation": [0, 0, 0.5],
+        },
+    ]
+
+
+def _mn3sn_spin_only_mirror():
+    return {
+        "spin_rotation": [[1, 0, 0], [0, 1, 0], [0, 0, -1]],
+        "real_rotation": IDENTITY,
+        "translation": [0, 0, 0],
+    }
+
+
+def identify_mn3sn():
+    """Identify Mn3Sn in the SSG-convention oriented setting."""
+    generators = _mn3sn_nssg_generators()
+    # Convention-oriented operation row 2: coplanar spin-only mirror.
+    generators.append(_mn3sn_spin_only_mirror())
+    return get_spin_space_group_from_operations(
+        generators,
+        spin_frame="oriented",
+    )
+
+
+def identify_mn3sn_with_explicit_spin_only_semantics():
+    """Supply Mn3Sn spin-only information separately from its nSSG generators."""
+    return get_spin_space_group_from_operations(
+        _mn3sn_nssg_generators(),
+        spin_configuration="coplanar",
+        # For coplanar order this is the spin-plane normal, not a spin axis.
+        spin_only_direction=[0, 0, 1],
+        spin_frame="oriented",
+    )
+
+
+def identify_mn3sn_convention_cartesian():
+    """Identify Mn3Sn with convention-cell operations and Cartesian spin."""
+    root_three_over_two = sqrt(3) / 2
+    generators = [
+        {
+            "spin_rotation": [
+                [-0.5, -root_three_over_two, 0],
+                [root_three_over_two, -0.5, 0],
+                [0, 0, 1],
+            ],
+            "real_rotation": [[1, -1, 0], [1, 0, 0], [0, 0, 1]],
+            "translation": [0, 0, 0.5],
+        },
+        {
+            "spin_rotation": IDENTITY,
+            "real_rotation": [[1, 0, 0], [0, 1, 0], [0, 0, -1]],
+            "translation": [0, 0, 0.5],
+        },
+        {
+            "spin_rotation": [
+                [0.5, -root_three_over_two, 0],
+                [-root_three_over_two, -0.5, 0],
+                [0, 0, -1],
+            ],
+            "real_rotation": [[-1, 1, 0], [0, 1, 0], [0, 0, 1]],
+            "translation": [0, 0, 0],
+        },
+        {
+            "spin_rotation": [
+                [0.5, root_three_over_two, 0],
+                [root_three_over_two, -0.5, 0],
+                [0, 0, -1],
+            ],
+            "real_rotation": [[-1, 0, 0], [-1, 1, 0], [0, 0, 1]],
+            "translation": [0, 0, 0.5],
+        },
+        _mn3sn_spin_only_mirror(),
+    ]
+    return get_spin_space_group_from_operations(
+        generators,
+        real_space_lattice=MN3SN_CONVENTION_LATTICE,
+    )
+
+
+def identify_mn3sn_magnetic_primitive_oriented():
+    """Identify Mn3Sn in its magnetic-primitive oriented setting."""
+    generators = _mn3sn_nssg_generators()
+    generators.append(_mn3sn_spin_only_mirror())
+    return get_spin_space_group_from_operations(
+        generators,
+        spin_frame="oriented",
+        real_space_lattice=MN3SN_MAGNETIC_PRIMITIVE_LATTICE,
+    )
+
+
+def identify_mnte():
+    """Return collinear MnTe, OSSG 194.164.1.1.L, from four generators.
+
+    ``ssg.ops`` contains the 96-operation finite representative used by the
+    core. The physical collinear group also contains the continuous C-infinity-v
+    spin-only component and therefore has infinitely many operations.
+    """
+    # 0.800_MnTe, convention-oriented nSSG rows 2, 5, 8, and 10.
+    generators = [
+        {
+            "spin_rotation": MINUS_IDENTITY,
+            "real_rotation": [[1, -1, 0], [1, 0, 0], [0, 0, 1]],
+            "translation": [0, 0, 0.5],
+        },
+        {
+            "spin_rotation": MINUS_IDENTITY,
+            "real_rotation": [[1, 0, 0], [0, 1, 0], [0, 0, -1]],
+            "translation": [0, 0, 0.5],
+        },
+        {
+            "spin_rotation": IDENTITY,
+            "real_rotation": [[-1, 1, 0], [0, 1, 0], [0, 0, 1]],
+            "translation": [0, 0, 0],
+        },
+        {
+            "spin_rotation": MINUS_IDENTITY,
+            "real_rotation": [[-1, 0, 0], [-1, 1, 0], [0, 0, 1]],
+            "translation": [0, 0, 0.5],
+        },
+    ]
+    return get_spin_space_group_from_operations(
+        generators,
+        spin_configuration="collinear",
+        # The collinear direction is expressed in the same oriented basis.
+        spin_only_direction=[1, 1, 0],
+        spin_frame="oriented",
+    )
+
+
+def identify_crse():
+    """Return noncoplanar CrSe, OSSG 194.149.3.3, from six generators."""
+    # 2.35_CrSe, convention-oriented operation rows 19, 32, 55, 64, 2, and 3.
+    generators = [
+        {
+            "spin_rotation": [[1, -1, 0], [0, -1, 0], [0, 0, -1]],
+            "real_rotation": [[1, -1, 0], [1, 0, 0], [0, 0, 1]],
+            "translation": [0, 0, 0.5],
+        },
+        {
+            "spin_rotation": MINUS_IDENTITY,
+            "real_rotation": [[1, 0, 0], [0, 1, 0], [0, 0, -1]],
+            "translation": [0, 0, 0.5],
+        },
+        {
+            "spin_rotation": [[-1, 1, 0], [0, 1, 0], [0, 0, 1]],
+            "real_rotation": [[-1, 1, 0], [0, 1, 0], [0, 0, 1]],
+            "translation": [0, 0, 0],
+        },
+        {
+            "spin_rotation": MINUS_IDENTITY,
+            "real_rotation": [[-1, 0, 0], [-1, 1, 0], [0, 0, 1]],
+            "translation": [0, 0, 0.5],
+        },
+        {
+            "spin_rotation": C3_ORIENTED,
+            "real_rotation": IDENTITY,
+            "translation": [0, 1 / 3, 0],
+        },
+        {
+            "spin_rotation": C3_ORIENTED,
+            "real_rotation": IDENTITY,
+            "translation": [1 / 3, 0, 0],
+        },
+    ]
+    # Identity-only spin-only content is inferred as noncoplanar.
+    return get_spin_space_group_from_operations(
+        generators,
+        spin_frame="oriented",
+    )
+
+
+def main():
+    examples = {
+        "Mn3Sn (spin-only operation included)": identify_mn3sn(),
+        "Mn3Sn (spin-only semantics supplied separately)": (
+            identify_mn3sn_with_explicit_spin_only_semantics()
+        ),
+        "Mn3Sn (convention Cartesian spin frame)": (
+            identify_mn3sn_convention_cartesian()
+        ),
+        "Mn3Sn (magnetic-primitive oriented setting)": (
+            identify_mn3sn_magnetic_primitive_oriented()
+        ),
+        "MnTe": identify_mnte(),
+        "CrSe": identify_crse(),
+    }
+    for material, ssg in examples.items():
+        operation_count = str(len(ssg.ops))
+        if ssg.conf == "Collinear":
+            operation_count += (
+                " finite representative operations; "
+                "full collinear group is infinite (spin-only C-infinity-v)"
+            )
+        print(
+            f"{material}: index={ssg.index}, conf={ssg.conf}, "
+            f"operations={operation_count}, G0={ssg.G0_num}, L0={ssg.L0_num}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
       - find_spin_group_basic: reference/api/find-spin-group-basic.md
       - find_spin_group: reference/api/find-spin-group.md
       - find_spin_group_input_ssg: reference/api/find-spin-group-input-ssg.md
+      - get_spin_space_group_from_operations: reference/api/get-spin-space-group-from-operations.md
   - Examples: guide/examples.md
   - Troubleshooting: guide/troubleshooting.md
   - Concepts And Settings: guide/concepts.md

--- a/site_docs/guide/choosing-an-api.md
+++ b/site_docs/guide/choosing-an-api.md
@@ -13,6 +13,7 @@ Choose from the scientific task, not from an internal object name.
 | Export SCIF in a chosen setting | `fsg FILE --write-scif OUT` | `result.to_scif(...)` | Full analysis |
 | Analyze a slab as quasi-2D | `fsg --full --calculation-mode quasi2d --vacuum-axis c FILE --show quasi_2d` | `find_spin_group(..., calculation_mode="quasi2d")` | Full analysis with quasi-2D interpretation payload |
 | Export operations in exactly the input cell | `fsg -w FILE` | `find_spin_group_input_ssg(FILE)` | Specialized operation export |
+| Identify a group from operation matrices or generators | none | `get_spin_space_group_from_operations(...)` | Operation-only `SpinSpaceGroup`; no material artifacts |
 
 ## Quick Analysis: The Default
 
@@ -90,6 +91,26 @@ an incomplete subgroup of the primitive-cell symmetry. Before consuming
 
 Use this route because a downstream program requires the input setting, not as
 a shortcut to the canonical OSSG identification.
+
+## Operations Without A Structure
+
+Use `get_spin_space_group_from_operations(...)` only when operations are the
+primary input. It accepts a complete finite operation set or generators,
+closes them modulo the declared or inferred spin-only subgroup, and returns an
+identified `SpinSpaceGroup`.
+
+This route can derive group-theoretic information such as index,
+configuration, G0/L0, translational indices, spin point groups, ACC, standard
+k-point templates, and operation-based symbols. It cannot infer atoms,
+Wyckoff splitting, net moment, magnetic phase, structure-dependent tensors, or
+files such as SCIF/POSCAR.
+
+MSG interpretation additionally requires spin and real rotations in one common
+physical coordinate representation. Merely labeling two independently
+oriented settings as "oriented" does not establish their relative frame. A
+Cartesian spin matrix paired with a fractional real-space matrix is sufficient
+for OSSG identification but not by itself for a physically meaningful SOC/MSG
+embedding.
 
 ## File Path Or Parsed Arrays?
 

--- a/site_docs/reference/api/get-spin-space-group-from-operations.md
+++ b/site_docs/reference/api/get-spin-space-group-from-operations.md
@@ -1,0 +1,194 @@
+# `get_spin_space_group_from_operations`
+
+Identify a spin space group directly from a complete operation set or a
+generator subset, without constructing a witness crystal.
+
+## Signature
+
+```python
+get_spin_space_group_from_operations(
+    operations,
+    *,
+    spin_configuration: str | None = None,
+    spin_only_direction=None,
+    spin_frame: str = "cartesian",
+    tol: float | Tolerances = 1e-6,
+    identify_tol: float = 1e-3,
+    max_operations: int = 4096,
+    real_space_lattice=None,
+    real_space_metric=None,
+    spin_metric=None,
+) -> SpinSpaceGroup
+```
+
+## Operation Format
+
+Each operation is ordered as:
+
+```python
+[spin_rotation, real_rotation, translation]
+```
+
+It may be a `SpinSpaceGroupOperation`, a three-item sequence, or:
+
+```python
+{
+    "spin_rotation": [[...], [...], [...]],
+    "real_rotation": [[...], [...], [...]],
+    "translation": [tx, ty, tz],
+}
+```
+
+The real rotation must be integral and unimodular in the current cell basis.
+Every translation component must already lie in `[0, 1)`. Values outside this
+range are rejected rather than silently reduced because an unreduced
+translation often signals a setting error.
+
+There is no default real-space convention or cell setting. The operation
+matrices define whichever current basis the caller supplies, such as SSG
+convention, magnetic primitive, or input. The frame default is
+`spin_frame="cartesian"`, which requires `real_space_lattice` or
+`real_space_metric`. Use `spin_frame="oriented"` explicitly when the spin
+matrices are already expressed in the current real-space setting basis.
+
+## Spin-Only Semantics
+
+`spin_configuration` accepts `collinear`, `coplanar`, or `noncoplanar`.
+
+- For collinear input, `spin_only_direction` is the magnetic axis.
+- For coplanar input, it is the normal to the spin plane.
+- It is not defined for noncoplanar input.
+
+If the type is omitted, the function closes the supplied finite operations and
+classifies their pure spin-only subgroup from its common fixed spin subspace.
+An identity-only subgroup is interpreted as noncoplanar. This is an explicit
+operation-only API convention: identity alone cannot distinguish a genuinely
+noncoplanar group from a collinear/coplanar input whose continuous spin-only
+component was omitted.
+
+External input does not need to contain FindSpinGroup's internal C2v
+collinear representative. The external spin-only subgroup is used to identify
+and validate the physical axis or plane, then the result is normalized to the
+finite representation expected by existing `SpinSpaceGroup` analysis methods.
+If the input already contains the complete internal spin-only representative,
+its exact operation matrices are retained.
+
+For collinear groups, `len(ssg.ops)` reports the size of this finite internal
+representative. It is not the order of the physical spin space group. The
+physical group contains the continuous spin-only component
+\(C_{\infty v}\) and consequently has infinitely many operations.
+
+## Spin Frame
+
+`spin_frame` accepts:
+
+- `cartesian` (default): spin rotations and `spin_only_direction` are expressed
+  in the same Cartesian coordinate system as the supplied lattice vectors.
+- `oriented`: spin rotations and `spin_only_direction` are expressed in the
+  current real-space setting basis.
+
+For Cartesian input with only `real_space_metric`, FindSpinGroup uses its
+default relative frame: `m_x` is parallel to lattice vector a, `m_y` is the
+positive component of b perpendicular to `m_x`, and
+`m_z = m_x cross m_y`.
+
+Supply `real_space_lattice`, whose rows are a, b, and c, when the Cartesian spin
+matrices use an existing global Cartesian frame rather than that default
+placement. This preserves the lattice's actual global orientation and
+handedness. When both lattice and metric are provided, the metric must equal:
+
+```python
+real_space_metric = real_space_lattice @ real_space_lattice.T
+```
+
+The function converts Cartesian spin data once at the input boundary and
+returns the group in the oriented setting representation used by existing
+OSSG and MSG analysis. This conversion does not run inside group closure.
+
+## Closure And Identification
+
+The function:
+
+1. validates matrices and strict mod-1 translations;
+2. closes the supplied operations or generators as a finite affine group;
+3. derives or validates the finite invariant spin metric;
+4. identifies the spin configuration and axis or plane;
+5. retains an already complete spin-only representation, or otherwise closes
+   the nontrivial quotient and restores the canonical finite component;
+6. constructs `SpinSpaceGroup` and resolves its database/convention `index`.
+
+`max_operations` is a safety bound. Exceeding it raises an error instead of
+returning a truncated group.
+
+A generator input must generate the complete affine group under the current
+cell translations. A symbol-level generator list may omit centering
+translations because they are implicit in the lattice symbol; this API receives
+no such symbol, so those centering or spin-translation generators must be
+included explicitly.
+
+## Available Analysis
+
+The returned object supports operation-derived `SpinSpaceGroup` properties,
+including:
+
+- `index`, `conf`, and spin-only direction;
+- G0/L0 symbols and numbers;
+- `it`, `ik`, spin translations, and pure translations;
+- nontrivial spin point-group and GSPG information;
+- arithmetic crystal class and standard k-point templates;
+- international SSG symbols and operation transforms;
+- MSG operations and symbols when the coordinate-frame condition below is
+  satisfied.
+
+The route has no atoms or physical cell. It therefore cannot provide Wyckoff
+or magnetic-site data, net moment, FM/FiM/AFM classification, structure-based
+tensor values, SCIF/POSCAR, or other material artifacts.
+
+## Coordinate-Frame Requirement For MSG
+
+SOC/MSG classification compares spin and axial real-space actions. Select the
+frame that describes the supplied spin matrices. For Cartesian input, provide
+either the real-space metric to select the default relative frame or the full
+lattice when the matrices use that lattice's existing global Cartesian frame.
+FindSpinGroup then performs the comparison in one common oriented
+representation.
+
+`msg_ops` remains available when magnetic operations can be classified.
+The downstream BNS/OG standardizer may return `msg_info=None` for a
+nonstandard or incomplete current cell even when another setting of the same
+OSSG is identifiable; this is a setting-standardization limitation, not a
+change of OSSG index.
+
+## Examples
+
+The executable repository example
+`examples/spin_space_group_from_operations.py` covers:
+
+- coplanar Mn3Sn with an explicit spin-only mirror;
+- the same Mn3Sn nSSG generators with spin-only semantics supplied separately;
+- Mn3Sn in convention Cartesian and magnetic-primitive oriented settings;
+- collinear MnTe with an explicit collinear direction;
+- noncoplanar CrSe.
+
+Minimal spin-translation example:
+
+```python
+import numpy as np
+from findspingroup import get_spin_space_group_from_operations
+
+spin_translation_generator = {
+    "spin_rotation": (-np.eye(3)).tolist(),
+    "real_rotation": np.eye(3).tolist(),
+    "translation": [0.5, 0, 0],
+}
+
+ssg = get_spin_space_group_from_operations(
+    [spin_translation_generator],
+    spin_configuration="collinear",
+    spin_only_direction=[0, 0, 1],
+    spin_frame="oriented",
+)
+
+assert ssg.index == "1.1.2.1.L"
+assert ssg.ik == 2
+```

--- a/site_docs/reference/python-api.md
+++ b/site_docs/reference/python-api.md
@@ -1,7 +1,7 @@
 # Python API: Start With The Scientific Task
 
-FindSpinGroup has three primary file-based functions. Most users need only the
-first one.
+FindSpinGroup has three primary file-based functions and one operation-only
+constructor. Most structure-analysis users need only the first function.
 
 ## Main Functions
 
@@ -10,12 +10,14 @@ first one.
 | Identify and screen a magnetic structure | `find_spin_group_basic(...)` | `BasicResult` dictionary | `index`, `magnetic_phase`, MSG fields, `properties` |
 | Inspect operations, settings, tensors, sites, or generated artifacts | `find_spin_group(...)` | `MagSymmetryResult` | a specific attribute or `to_structured_dict()` Python view |
 | Export operations in the user-supplied cell | `find_spin_group_input_ssg(...)` | `InputSSGResult` dictionary | primitive-cell warning, then `ssg`/`msg` |
+| Identify an SSG from complete operations or generators | `get_spin_space_group_from_operations(...)` | `SpinSpaceGroup` | `index`, `conf`, G0/L0, ACC, point groups |
 
 Detailed pages:
 
 - [`find_spin_group_basic`](api/find-spin-group-basic.md)
 - [`find_spin_group`](api/find-spin-group.md)
 - [`find_spin_group_input_ssg`](api/find-spin-group-input-ssg.md)
+- [`get_spin_space_group_from_operations`](api/get-spin-space-group-from-operations.md)
 
 ## Recommended First Call
 
@@ -111,6 +113,36 @@ Use `find_spin_group_from_data(...)`, `find_spin_group_basic_from_data(...)`, or
 already owns parsed lattice, position, species, occupancy, and moment arrays.
 The file-based functions are safer for ordinary use because they also preserve
 input-format metadata and spin-frame conventions.
+
+## Operation-Only Identification
+
+Use `get_spin_space_group_from_operations(...)` when another program already
+owns SSG operations or generators and no atomic structure is available:
+
+```python
+from findspingroup import get_spin_space_group_from_operations
+
+ssg = get_spin_space_group_from_operations(
+    generators,
+    spin_configuration="collinear",
+    spin_only_direction=[0, 0, 1],
+    spin_frame="oriented",
+)
+
+print(ssg.index, ssg.G0_num, ssg.L0_num)
+print(ssg.acc, ssg.n_spin_part_point_group_symbol_s)
+```
+
+This route performs finite affine closure, completes the finite spin-only
+representative used by the core, and identifies the database/convention index.
+It does not construct a fictitious magnetic crystal. Consequently it cannot
+produce atom-, cell-, Wyckoff-, net-moment-, SCIF-, POSCAR-, or
+material-classification results.
+
+For SOC/MSG analysis, spin and real rotations must be expressed in one common
+physical coordinate representation. See the
+[operation-only API contract](api/get-spin-space-group-from-operations.md)
+before using `ssg.msg_info`.
 
 ## Interpretation Rule
 

--- a/src/findspingroup/__init__.py
+++ b/src/findspingroup/__init__.py
@@ -11,6 +11,9 @@ from .find_spin_group import (
     write_ssg_operation_matrices,
 )
 from .examples import example_path
+from .core.spin_space_group_from_operations import (
+    get_spin_space_group_from_operations,
+)
 
 __all__ = [
     'find_spin_group',
@@ -21,6 +24,7 @@ __all__ = [
     'find_spin_group_from_data',
     'find_spin_group_input_ssg',
     'find_spin_group_poscar_ssg',
+    'get_spin_space_group_from_operations',
     'example_path',
     'write_poscar_ssg_symmetry_dat',
     'write_ssg_operation_matrices',

--- a/src/findspingroup/core/spin_space_group_from_operations.py
+++ b/src/findspingroup/core/spin_space_group_from_operations.py
@@ -1,0 +1,891 @@
+"""Construct an identified spin space group directly from symmetry operations."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from itertools import product
+
+import numpy as np
+
+from findspingroup.core.identify_spin_space_group import _semantic_collinear_pg_ops
+from findspingroup.core.tolerances import Tolerances
+from findspingroup.structure.group import SpinSpaceGroup, SpinSpaceGroupOperation
+
+
+_IDENTITY = np.eye(3)
+_ZERO = np.zeros(3)
+_CONFIGURATION_NAMES = {
+    "collinear": "Collinear",
+    "coplanar": "Coplanar",
+    "noncoplanar": "Noncoplanar",
+    "non-coplanar": "Noncoplanar",
+}
+_SPIN_FRAMES = {"oriented", "cartesian"}
+
+
+def _operation_tolerance(tol: float | Tolerances) -> float:
+    value = tol.m_matrix_tol if isinstance(tol, Tolerances) else float(tol)
+    if not np.isfinite(value) or value <= 0 or value >= 0.5:
+        raise ValueError("tol must be finite and satisfy 0 < tol < 0.5")
+    return value
+
+
+def _normalize_configuration(value: str | None) -> str | None:
+    if value is None:
+        return None
+    key = str(value).strip().lower().replace("_", "-")
+    try:
+        return _CONFIGURATION_NAMES[key]
+    except KeyError as exc:
+        allowed = ", ".join(sorted(set(_CONFIGURATION_NAMES.values())))
+        raise ValueError(
+            f"spin_configuration must be one of {allowed}, got {value!r}"
+        ) from exc
+
+
+def _normalize_spin_frame(value: str) -> str:
+    frame = str(value).strip().lower()
+    if frame not in _SPIN_FRAMES:
+        allowed = ", ".join(sorted(_SPIN_FRAMES))
+        raise ValueError(f"spin_frame must be one of {allowed}, got {value!r}")
+    return frame
+
+
+def _normalize_real_space_metric(metric) -> np.ndarray | None:
+    if metric is None:
+        return None
+    normalized = np.asarray(metric, dtype=float)
+    if normalized.shape != (3, 3) or not np.all(np.isfinite(normalized)):
+        raise ValueError("real_space_metric must be a finite 3x3 matrix")
+    normalized = 0.5 * (normalized + normalized.T)
+    if np.min(np.linalg.eigvalsh(normalized)) <= 0:
+        raise ValueError("real_space_metric must be positive definite")
+    return normalized
+
+
+def _normalize_real_space_lattice(lattice) -> np.ndarray | None:
+    if lattice is None:
+        return None
+    normalized = np.asarray(lattice, dtype=float)
+    if normalized.shape != (3, 3) or not np.all(np.isfinite(normalized)):
+        raise ValueError("real_space_lattice must be a finite 3x3 matrix")
+    if abs(float(np.linalg.det(normalized))) <= 1e-12:
+        raise ValueError("real_space_lattice must be nonsingular")
+    return normalized
+
+
+def _resolve_real_space_geometry(real_space_lattice, real_space_metric):
+    lattice = _normalize_real_space_lattice(real_space_lattice)
+    metric = _normalize_real_space_metric(real_space_metric)
+    if lattice is None:
+        return None, metric
+    lattice_metric = lattice @ lattice.T
+    if metric is not None and not np.allclose(
+        metric,
+        lattice_metric,
+        atol=1e-8,
+        rtol=1e-8,
+    ):
+        raise ValueError(
+            "real_space_metric is inconsistent with real_space_lattice"
+        )
+    return lattice, lattice_metric
+
+
+def _setting_to_cartesian_transform(
+    real_space_lattice,
+    real_space_metric,
+) -> np.ndarray:
+    """Map setting coordinates to the selected Cartesian spin frame."""
+    lattice = _normalize_real_space_lattice(real_space_lattice)
+    if lattice is not None:
+        return lattice.T
+
+    metric = _normalize_real_space_metric(real_space_metric)
+    if metric is None:
+        raise ValueError(
+            "real_space_lattice or real_space_metric is required when "
+            "spin_frame='cartesian'"
+        )
+    # The upper-triangular Cholesky factor places a along mx, b in the
+    # mx-my plane with positive my, and mz = mx x my.
+    return np.linalg.cholesky(metric).T
+
+
+def _normalize_input_spin_frame(
+    operations,
+    *,
+    spin_frame: str,
+    spin_only_direction,
+    real_space_lattice,
+    real_space_metric,
+    spin_metric,
+):
+    """Convert input spin data once to the oriented setting representation."""
+    if spin_frame == "oriented":
+        effective_spin_metric = (
+            real_space_metric
+            if spin_metric is None and real_space_metric is not None
+            else spin_metric
+        )
+        return operations, spin_only_direction, effective_spin_metric
+
+    setting_to_cartesian = _setting_to_cartesian_transform(
+        real_space_lattice,
+        real_space_metric,
+    )
+    cartesian_to_setting = np.linalg.inv(setting_to_cartesian)
+    normalized_operations = [
+        SpinSpaceGroupOperation(
+            cartesian_to_setting
+            @ operation.spin_rotation
+            @ setting_to_cartesian,
+            operation.rotation,
+            operation.translation,
+        )
+        for operation in operations
+    ]
+    normalized_direction = None
+    if spin_only_direction is not None:
+        direction = np.asarray(spin_only_direction, dtype=float)
+        if direction.shape != (3,) or not np.all(np.isfinite(direction)):
+            raise ValueError(
+                "spin_only_direction must be a finite length-3 vector"
+            )
+        normalized_direction = cartesian_to_setting @ direction
+    cartesian_metric = (
+        np.eye(3)
+        if spin_metric is None
+        else np.asarray(spin_metric, dtype=float)
+    )
+    normalized_spin_metric = (
+        setting_to_cartesian.T
+        @ cartesian_metric
+        @ setting_to_cartesian
+    )
+    return (
+        normalized_operations,
+        normalized_direction,
+        normalized_spin_metric,
+    )
+
+
+def _normalize_direction(direction, *, metric, name: str) -> np.ndarray:
+    vector = np.asarray(direction, dtype=float)
+    if vector.shape != (3,) or not np.all(np.isfinite(vector)):
+        raise ValueError(f"{name} must be a finite length-3 vector")
+    norm = float(np.sqrt(vector @ metric @ vector))
+    if norm <= 1e-12:
+        raise ValueError(f"{name} must be nonzero")
+    vector = vector / norm
+    for component in vector:
+        if abs(component) <= 1e-12:
+            continue
+        if component < 0:
+            vector = -vector
+        break
+    return vector
+
+
+def _deserialize_operation(raw, *, index: int, tol: float) -> SpinSpaceGroupOperation:
+    if isinstance(raw, SpinSpaceGroupOperation):
+        spin_rotation = raw.spin_rotation
+        real_rotation = raw.rotation
+        translation = raw.translation
+    elif isinstance(raw, dict):
+        required = {"spin_rotation", "translation"}
+        missing = required - raw.keys()
+        if missing:
+            raise ValueError(
+                f"operation {index} is missing fields: {', '.join(sorted(missing))}"
+            )
+        if "real_rotation" in raw:
+            real_rotation = raw["real_rotation"]
+        elif "rotation" in raw:
+            real_rotation = raw["rotation"]
+        else:
+            raise ValueError(
+                f"operation {index} is missing field: real_rotation"
+            )
+        spin_rotation = raw["spin_rotation"]
+        translation = raw["translation"]
+    elif (
+        isinstance(raw, (Sequence, np.ndarray))
+        and not isinstance(raw, (str, bytes))
+        and len(raw) == 3
+    ):
+        spin_rotation, real_rotation, translation = raw
+    else:
+        raise TypeError(
+            "operations must contain SpinSpaceGroupOperation objects, serialized "
+            "dicts, or [spin_rotation, real_rotation, translation] sequences"
+        )
+
+    spin_rotation = np.asarray(spin_rotation, dtype=float)
+    real_rotation = np.asarray(real_rotation, dtype=float)
+    translation = np.asarray(translation, dtype=float)
+    if spin_rotation.shape != (3, 3):
+        raise ValueError(
+            f"operation {index} spin_rotation must have shape (3, 3)"
+        )
+    if real_rotation.shape != (3, 3):
+        raise ValueError(
+            f"operation {index} real_rotation must have shape (3, 3)"
+        )
+    if translation.shape == (3, 1):
+        translation = translation.reshape(3)
+    if translation.shape != (3,):
+        raise ValueError(
+            f"operation {index} translation must have shape (3,)"
+        )
+    if not (
+        np.all(np.isfinite(spin_rotation))
+        and np.all(np.isfinite(real_rotation))
+        and np.all(np.isfinite(translation))
+    ):
+        raise ValueError(f"operation {index} contains non-finite values")
+    if np.any(translation < 0) or np.any(translation >= 1):
+        raise ValueError(
+            f"operation {index} translation must lie in [0, 1) componentwise"
+        )
+
+    spin_determinant = float(np.linalg.det(spin_rotation))
+    if not np.isclose(abs(spin_determinant), 1.0, atol=tol, rtol=0):
+        raise ValueError(
+            f"operation {index} spin_rotation must be a finite metric-preserving "
+            "matrix with determinant +1 or -1"
+        )
+
+    rounded_real_rotation = np.rint(real_rotation)
+    if not np.allclose(real_rotation, rounded_real_rotation, atol=tol, rtol=0):
+        raise ValueError(
+            f"operation {index} real_rotation must be integral in the input cell basis"
+        )
+    real_determinant = float(np.linalg.det(rounded_real_rotation))
+    if not np.isclose(abs(real_determinant), 1.0, atol=tol, rtol=0):
+        raise ValueError(
+            f"operation {index} real_rotation must be unimodular"
+        )
+
+    return SpinSpaceGroupOperation(
+        spin_rotation,
+        rounded_real_rotation,
+        translation,
+    )
+
+
+def _translation_close(left, right, *, tol: float) -> bool:
+    difference = np.mod(
+        np.asarray(left, dtype=float) - np.asarray(right, dtype=float) + 0.5,
+        1.0,
+    ) - 0.5
+    return bool(np.max(np.abs(difference)) <= tol)
+
+
+def _operations_same(left, right, *, tol: float) -> bool:
+    if np.max(
+        np.abs(left.spin_rotation - right.spin_rotation)
+    ) > tol:
+        return False
+    if np.max(np.abs(left.rotation - right.rotation)) > tol:
+        return False
+    return _translation_close(
+        left.translation,
+        right.translation,
+        tol=tol,
+    )
+
+
+class _OperationLookup:
+    """Tolerance-aware lookup keyed by exact lattice action and periodic bins."""
+
+    def __init__(self, *, tol: float):
+        self.tol = tol
+        self.translation_bins = max(1, int(np.floor(1.0 / tol)))
+        self.operations = []
+        self._buckets = {}
+
+    @staticmethod
+    def _rotation_key(operation):
+        return tuple(np.rint(operation.rotation).astype(int).reshape(-1))
+
+    def _translation_key(self, translation):
+        wrapped = np.mod(np.asarray(translation, dtype=float), 1.0)
+        return tuple(
+            np.floor(wrapped * self.translation_bins).astype(int)
+            % self.translation_bins
+        )
+
+    def _candidate_keys(self, operation):
+        rotation_key = self._rotation_key(operation)
+        translation_key = self._translation_key(operation.translation)
+        for offsets in product((-1, 0, 1), repeat=3):
+            yield (
+                rotation_key,
+                tuple(
+                    (component + offset) % self.translation_bins
+                    for component, offset in zip(translation_key, offsets)
+                ),
+            )
+
+    def contains(self, candidate) -> bool:
+        for key in self._candidate_keys(candidate):
+            for existing in self._buckets.get(key, ()):
+                if _operations_same(candidate, existing, tol=self.tol):
+                    return True
+        return False
+
+    def add(self, operation) -> bool:
+        if self.contains(operation):
+            return False
+        self.operations.append(operation)
+        key = (
+            self._rotation_key(operation),
+            self._translation_key(operation.translation),
+        )
+        self._buckets.setdefault(key, []).append(operation)
+        return True
+
+
+def _compose(left, right) -> SpinSpaceGroupOperation:
+    translation = np.mod(
+        left.rotation @ right.translation + left.translation,
+        1.0,
+    )
+    translation[np.isclose(translation, 1.0, atol=1e-12, rtol=0)] = 0.0
+    return SpinSpaceGroupOperation(
+        left.spin_rotation @ right.spin_rotation,
+        left.rotation @ right.rotation,
+        translation,
+    )
+
+
+def _inverse(operation) -> SpinSpaceGroupOperation:
+    real_inverse = np.linalg.inv(operation.rotation)
+    spin_inverse = np.linalg.inv(operation.spin_rotation)
+    translation = np.mod(-real_inverse @ operation.translation, 1.0)
+    translation[np.isclose(translation, 1.0, atol=1e-12, rtol=0)] = 0.0
+    return SpinSpaceGroupOperation(spin_inverse, real_inverse, translation)
+
+
+def _close_operations(
+    generators,
+    *,
+    tol: float,
+    max_operations: int,
+    canonicalize=None,
+):
+    if max_operations < 1:
+        raise ValueError("max_operations must be positive")
+
+    identity = SpinSpaceGroupOperation.identity()
+    if canonicalize is not None:
+        identity = canonicalize(identity)
+    word_lookup = _OperationLookup(tol=tol)
+    for generator in generators:
+        for word in (generator, _inverse(generator)):
+            word = canonicalize(word) if canonicalize is not None else word
+            word_lookup.add(word)
+
+    closure_lookup = _OperationLookup(tol=tol)
+    closure_lookup.add(identity)
+    queue_index = 0
+    while queue_index < len(closure_lookup.operations):
+        current = closure_lookup.operations[queue_index]
+        queue_index += 1
+        for word in word_lookup.operations:
+            candidate = _compose(current, word)
+            if canonicalize is not None:
+                candidate = canonicalize(candidate)
+            if not closure_lookup.add(candidate):
+                continue
+            if len(closure_lookup.operations) > max_operations:
+                raise ValueError(
+                    "operation closure exceeded max_operations; the inputs do not "
+                    "define a finite spin space group under the active tolerance"
+                )
+    return closure_lookup.operations
+
+
+def _close_operation_input(operations, *, tol: float, max_operations: int):
+    """Close either a complete operation list or a generator subset efficiently."""
+    input_lookup = _OperationLookup(tol=tol)
+    for operation in operations:
+        input_lookup.add(operation)
+
+    selected_generators = []
+    closure = [SpinSpaceGroupOperation.identity()]
+    closure_lookup = _OperationLookup(tol=tol)
+    closure_lookup.add(closure[0])
+    for operation in operations:
+        if closure_lookup.contains(operation):
+            continue
+        selected_generators.append(operation)
+        closure = _close_operations(
+            selected_generators,
+            tol=tol,
+            max_operations=max_operations,
+        )
+        closure_lookup = _OperationLookup(tol=tol)
+        for closed_operation in closure:
+            closure_lookup.add(closed_operation)
+    if (
+        len(input_lookup.operations) == len(closure_lookup.operations)
+        and all(input_lookup.contains(operation) for operation in closure)
+    ):
+        # Preserve the caller's exact matrices when the supplied operations
+        # already form the complete group. Reconstructing them as generator
+        # words can accumulate avoidable floating-point noise.
+        return input_lookup.operations
+    # Matrix products of nonorthogonal finite-order generators accumulate
+    # machine-epsilon noise. Stabilize only generated representatives; the
+    # requested precision remains far below the public operation tolerance.
+    return [
+        SpinSpaceGroupOperation(
+            np.round(operation.spin_rotation, decimals=12),
+            np.rint(operation.rotation),
+            np.mod(np.round(operation.translation, decimals=12), 1.0),
+        )
+        for operation in closure
+    ]
+
+
+def _is_spin_only(operation, *, tol: float) -> bool:
+    return bool(
+        np.allclose(operation.rotation, _IDENTITY, atol=tol, rtol=0)
+        and _translation_close(operation.translation, _ZERO, tol=tol)
+    )
+
+
+def _fixed_subspace(spin_rotations, *, tol: float):
+    constraints = np.vstack(
+        [np.asarray(rotation, dtype=float) - _IDENTITY for rotation in spin_rotations]
+    )
+    _, singular_values, right_vectors = np.linalg.svd(constraints)
+    threshold = max(tol, np.finfo(float).eps * max(constraints.shape))
+    rank = int(np.count_nonzero(singular_values > threshold))
+    return right_vectors[rank:].T
+
+
+def _invariant_spin_metric(operations, *, tol: float, spin_metric=None):
+    if spin_metric is None:
+        metric = sum(
+            operation.spin_rotation.T @ operation.spin_rotation
+            for operation in operations
+        ) / len(operations)
+    else:
+        metric = np.asarray(spin_metric, dtype=float)
+        if metric.shape != (3, 3) or not np.all(np.isfinite(metric)):
+            raise ValueError("spin_metric must be a finite 3x3 matrix")
+        metric = 0.5 * (metric + metric.T)
+
+    eigenvalues = np.linalg.eigvalsh(metric)
+    if np.min(eigenvalues) <= tol:
+        raise ValueError("spin_metric must be positive definite")
+    metric = metric / float(np.linalg.det(metric)) ** (1.0 / 3.0)
+    for operation in operations:
+        transformed = operation.spin_rotation.T @ metric @ operation.spin_rotation
+        if not np.allclose(transformed, metric, atol=max(tol, 1e-8), rtol=0):
+            raise ValueError(
+                "spin rotations do not preserve a common finite "
+                "positive-definite metric"
+            )
+    return metric
+
+
+def _infer_spin_only_semantics(operations, *, metric, tol: float):
+    rotations = [
+        operation.spin_rotation
+        for operation in operations
+        if _is_spin_only(operation, tol=tol)
+    ]
+    if not rotations:
+        return "Noncoplanar", None
+    if all(np.allclose(rotation, _IDENTITY, atol=tol, rtol=0) for rotation in rotations):
+        return "Noncoplanar", None
+
+    fixed_subspace = _fixed_subspace(rotations, tol=tol)
+    dimension = fixed_subspace.shape[1]
+    if dimension == 1:
+        return "Collinear", _normalize_direction(
+            fixed_subspace[:, 0],
+            metric=metric,
+            name="inferred collinear direction",
+        )
+    if dimension == 2:
+        coordinate_normal = np.cross(
+            fixed_subspace[:, 0],
+            fixed_subspace[:, 1],
+        )
+        normal = np.linalg.solve(metric, coordinate_normal)
+        return "Coplanar", _normalize_direction(
+            normal,
+            metric=metric,
+            name="inferred coplanar plane normal",
+        )
+    if dimension == 3:
+        return "Noncoplanar", None
+    raise ValueError(
+        "the finite spin-only operations have no common fixed spin subspace; "
+        "provide a physically consistent spin-only subgroup"
+    )
+
+
+def _directions_parallel(left, right, *, metric, tol: float) -> bool:
+    return bool(abs(float(left @ metric @ right)) >= 1.0 - tol)
+
+
+def _resolve_spin_only_semantics(
+    operations,
+    *,
+    requested_configuration: str | None,
+    requested_direction,
+    metric,
+    tol: float,
+):
+    inferred_configuration, inferred_direction = _infer_spin_only_semantics(
+        operations,
+        metric=metric,
+        tol=tol,
+    )
+    if requested_configuration is None:
+        if requested_direction is not None:
+            raise ValueError(
+                "spin_only_direction requires an explicit spin_configuration"
+            )
+        return inferred_configuration, inferred_direction
+
+    if (
+        inferred_configuration != "Noncoplanar"
+        and inferred_configuration != requested_configuration
+    ):
+        raise ValueError(
+            f"spin_configuration={requested_configuration!r} conflicts with the "
+            f"finite spin-only subgroup, which implies {inferred_configuration!r}"
+        )
+    if requested_configuration == "Noncoplanar":
+        if requested_direction is not None:
+            raise ValueError(
+                "spin_only_direction is not defined for noncoplanar spin configurations"
+            )
+        if inferred_configuration != "Noncoplanar":
+            raise ValueError(
+                "spin_configuration='Noncoplanar' conflicts with a nontrivial "
+                "finite spin-only subgroup"
+            )
+        return requested_configuration, None
+
+    if requested_direction is None:
+        if inferred_direction is None:
+            raise ValueError(
+                f"spin_only_direction is required for explicit "
+                f"{requested_configuration.lower()} input when the operations "
+                "do not determine it"
+            )
+        return requested_configuration, inferred_direction
+
+    direction = _normalize_direction(
+        requested_direction,
+        metric=metric,
+        name="spin_only_direction",
+    )
+    if inferred_direction is not None and not _directions_parallel(
+        direction,
+        inferred_direction,
+        metric=metric,
+        tol=max(tol, 1e-8),
+    ):
+        raise ValueError(
+            "spin_only_direction conflicts with the direction implied by the "
+            "finite spin-only subgroup"
+        )
+    return requested_configuration, direction
+
+
+def _coplanar_mirror(normal, *, metric) -> np.ndarray:
+    normal = np.asarray(normal, dtype=float).reshape(3)
+    return _IDENTITY - 2.0 * np.outer(normal, metric @ normal)
+
+
+def _metric_norm(vector, metric) -> float:
+    vector = np.asarray(vector, dtype=float)
+    return float(np.sqrt(vector @ metric @ vector))
+
+
+def _quotient_canonicalizer(configuration: str, direction, *, metric, tol: float):
+    if configuration == "Noncoplanar":
+        return lambda operation: operation
+
+    if configuration == "Collinear":
+        axis = np.asarray(direction, dtype=float)
+
+        def canonicalize(operation):
+            mapped = operation.spin_rotation @ axis
+            projection = float(mapped @ metric @ axis)
+            residual = _metric_norm(mapped - projection * axis, metric)
+            if residual > tol or not np.isclose(abs(projection), 1.0, atol=tol, rtol=0):
+                raise ValueError(
+                    "a spin rotation does not preserve the declared collinear axis"
+                )
+            spin_rotation = _IDENTITY if projection > 0 else -_IDENTITY
+            return SpinSpaceGroupOperation(
+                spin_rotation,
+                operation.rotation,
+                operation.translation,
+            )
+
+        return canonicalize
+
+    normal = np.asarray(direction, dtype=float)
+    mirror = _coplanar_mirror(normal, metric=metric)
+
+    def canonicalize(operation):
+        mapped = operation.spin_rotation @ normal
+        projection = float(mapped @ metric @ normal)
+        residual = _metric_norm(mapped - projection * normal, metric)
+        if residual > tol or not np.isclose(abs(projection), 1.0, atol=tol, rtol=0):
+            raise ValueError(
+                "a spin rotation does not preserve the declared coplanar spin plane"
+            )
+        spin_rotation = operation.spin_rotation
+        if np.linalg.det(spin_rotation) < 0:
+            spin_rotation = spin_rotation @ mirror
+        return SpinSpaceGroupOperation(
+            spin_rotation,
+            operation.rotation,
+            operation.translation,
+        )
+
+    return canonicalize
+
+
+def _metric_cartesian_transform(metric):
+    eigenvalues, eigenvectors = np.linalg.eigh(metric)
+    return np.diag(np.sqrt(eigenvalues)) @ eigenvectors.T
+
+
+def _canonical_spin_only_rotations(configuration: str, direction, *, metric):
+    if configuration == "Noncoplanar":
+        return [_IDENTITY]
+    if configuration == "Coplanar":
+        return [_IDENTITY, _coplanar_mirror(direction, metric=metric)]
+
+    to_cartesian = _metric_cartesian_transform(metric)
+    from_cartesian = np.linalg.inv(to_cartesian)
+    cartesian_axis = to_cartesian @ np.asarray(direction, dtype=float)
+    cartesian_axis = cartesian_axis / np.linalg.norm(cartesian_axis)
+    cartesian_ops = _semantic_collinear_pg_ops(
+        cartesian_axis,
+        include_axis_flip=False,
+    )
+    return [
+        _IDENTITY,
+        *[
+            from_cartesian @ operation @ to_cartesian
+            for operation in cartesian_ops
+        ],
+    ]
+
+
+def _lift_spin_only_group(
+    quotient_operations,
+    *,
+    configuration: str,
+    direction,
+    metric,
+    tol: float,
+):
+    lifted = _OperationLookup(tol=tol)
+    for spin_only_rotation in _canonical_spin_only_rotations(
+        configuration,
+        direction,
+        metric=metric,
+    ):
+        for operation in quotient_operations:
+            candidate = SpinSpaceGroupOperation(
+                spin_only_rotation @ operation.spin_rotation,
+                operation.rotation,
+                operation.translation,
+            )
+            lifted.add(candidate)
+    return lifted.operations
+
+
+def _has_internal_spin_only_contract(
+    operations,
+    *,
+    configuration: str,
+    tol: float,
+) -> bool:
+    spin_only_order = sum(
+        _is_spin_only(operation, tol=tol)
+        for operation in operations
+    )
+    if configuration == "Noncoplanar":
+        return spin_only_order == 1
+    if configuration == "Coplanar":
+        return spin_only_order == 2
+    return spin_only_order in {4, 8}
+
+
+def get_spin_space_group_from_operations(
+    operations,
+    *,
+    spin_configuration: str | None = None,
+    spin_only_direction=None,
+    spin_frame: str = "cartesian",
+    tol: float | Tolerances = 1e-6,
+    identify_tol: float = 1e-3,
+    max_operations: int = 4096,
+    real_space_lattice=None,
+    real_space_metric=None,
+    spin_metric=None,
+) -> SpinSpaceGroup:
+    """Return an identified :class:`SpinSpaceGroup` from operations or generators.
+
+    Examples
+    --------
+    See ``examples/spin_space_group_from_operations.py`` for executable
+    coplanar Mn3Sn and collinear MnTe generator examples.
+
+    ``operations`` may contain the complete group or a generator subset. Each
+    entry may be a :class:`SpinSpaceGroupOperation`, a serialized dictionary,
+    or a three-item sequence. Centering translations and spin translations
+    that are implicit in a printed group symbol must be supplied explicitly
+    when they are needed to generate the group.
+
+    Input operations use ``[spin_rotation, real_rotation, translation]`` order.
+    Translations must already be reduced componentwise to ``[0, 1)`` in the
+    current cell basis. The finite invariant metric of the supplied spin
+    matrices is derived automatically; ``spin_metric`` can provide it
+    explicitly.
+
+    ``spin_only_direction`` is the collinear axis or the coplanar plane normal.
+    When no configuration is supplied, the finite spin-only subgroup is
+    inferred. An identity-only spin-only subgroup is interpreted as
+    noncoplanar by this operation-only API.
+
+    No real-space cell convention is assumed. ``real_rotation`` and
+    ``translation`` are interpreted in the current basis supplied by the
+    caller. The frame default is ``spin_frame="cartesian"``.
+
+    ``spin_frame="cartesian"`` means spin matrices and directions use the same
+    Cartesian coordinates as the supplied lattice. It is the default and
+    requires ``real_space_lattice`` or ``real_space_metric``.
+    ``spin_frame="oriented"`` means spin coordinates already use the current
+    real-space setting basis.
+    The lattice and spin frame are jointly reduced to the default relative
+    frame with x parallel to a, y in the ab plane, and z=x cross y. Supplying
+    only ``real_space_metric`` selects that default relative frame. Supplying
+    ``real_space_lattice`` with row vectors a, b, and c instead preserves its
+    actual global Cartesian orientation. The returned group uses the oriented
+    representation expected by downstream OSSG/MSG analysis. For example,
+    ``ssg.index``, ``ssg.G0_num``, ``ssg.L0_num``, group symbols,
+    translations, ACC/k-point information, and operation-derived MSG
+    information remain available. Structure-derived atoms, Wyckoff data,
+    magnetic phase, SCIF, and POSCAR require a structure-based FindSpinGroup
+    route instead.
+
+    For a collinear group, ``len(ssg.ops)`` is the order of FindSpinGroup's
+    finite internal representative, not the order of the physical spin space
+    group. The latter contains a continuous C-infinity-v spin-only component
+    and therefore has infinitely many operations.
+    """
+    operation_tol = _operation_tolerance(tol)
+    normalized_spin_frame = _normalize_spin_frame(spin_frame)
+    (
+        normalized_real_space_lattice,
+        normalized_real_space_metric,
+    ) = _resolve_real_space_geometry(
+        real_space_lattice,
+        real_space_metric,
+    )
+    if not np.isfinite(identify_tol) or identify_tol <= 0:
+        raise ValueError("identify_tol must be a finite positive number")
+
+    try:
+        raw_operations = list(operations)
+    except TypeError as exc:
+        raise TypeError("operations must be an iterable of operations") from exc
+    if not raw_operations:
+        raise ValueError("operations must contain at least one operation or generator")
+
+    parsed_operations = [
+        _deserialize_operation(raw, index=index, tol=operation_tol)
+        for index, raw in enumerate(raw_operations)
+    ]
+    (
+        parsed_operations,
+        spin_only_direction,
+        spin_metric,
+    ) = _normalize_input_spin_frame(
+        parsed_operations,
+        spin_frame=normalized_spin_frame,
+        spin_only_direction=spin_only_direction,
+        real_space_lattice=normalized_real_space_lattice,
+        real_space_metric=normalized_real_space_metric,
+        spin_metric=spin_metric,
+    )
+    requested_configuration = _normalize_configuration(spin_configuration)
+
+    finite_closure = _close_operation_input(
+        parsed_operations,
+        tol=operation_tol,
+        max_operations=max_operations,
+    )
+    metric = _invariant_spin_metric(
+        finite_closure,
+        tol=operation_tol,
+        spin_metric=spin_metric,
+    )
+    configuration, direction = _resolve_spin_only_semantics(
+        finite_closure,
+        requested_configuration=requested_configuration,
+        requested_direction=spin_only_direction,
+        metric=metric,
+        tol=operation_tol,
+    )
+
+    if _has_internal_spin_only_contract(
+        finite_closure,
+        configuration=configuration,
+        tol=operation_tol,
+    ):
+        complete_operations = finite_closure
+    else:
+        canonicalize = _quotient_canonicalizer(
+            configuration,
+            direction,
+            metric=metric,
+            tol=operation_tol,
+        )
+        quotient_operations = _close_operations(
+            finite_closure,
+            tol=operation_tol,
+            max_operations=max_operations,
+            canonicalize=canonicalize,
+        )
+        complete_operations = _lift_spin_only_group(
+            quotient_operations,
+            configuration=configuration,
+            direction=direction,
+            metric=metric,
+            tol=operation_tol,
+        )
+    if len(complete_operations) > max_operations:
+        raise ValueError(
+            "canonical spin-only completion exceeded max_operations"
+        )
+
+    group = SpinSpaceGroup(
+        complete_operations,
+        tol=operation_tol,
+        real_space_metric=normalized_real_space_metric,
+        identify_source_name="<operation input>",
+        identify_tol=float(identify_tol),
+    )
+    group.input_spin_frame = normalized_spin_frame
+    group.spin_settings = "oriented"
+    group.relative_settings = "OSSG"
+    group.index
+    return group

--- a/tests/test_spin_space_group_from_operations.py
+++ b/tests/test_spin_space_group_from_operations.py
@@ -1,0 +1,554 @@
+import numpy as np
+import pytest
+
+from findspingroup import find_spin_group, get_spin_space_group_from_operations
+from findspingroup.structure import SpinSpaceGroup, SpinSpaceGroupOperation
+from examples.spin_space_group_from_operations import (
+    identify_crse,
+    identify_mn3sn,
+    identify_mn3sn_convention_cartesian,
+    identify_mn3sn_magnetic_primitive_oriented,
+    identify_mn3sn_with_explicit_spin_only_semantics,
+    identify_mnte,
+)
+
+
+IDENTITY = np.eye(3)
+ZERO = np.zeros(3)
+
+
+def _operation(spin_rotation=IDENTITY, real_rotation=IDENTITY, translation=ZERO):
+    return SpinSpaceGroupOperation(spin_rotation, real_rotation, translation)
+
+
+@pytest.mark.parametrize(
+    ("configuration", "expected_configuration", "expected_order", "expected_index"),
+    [
+        (None, "Noncoplanar", 1, "1.1.1.1"),
+        ("coplanar", "Coplanar", 2, "1.1.1.1.P"),
+        ("collinear", "Collinear", 4, "1.1.1.1.L"),
+    ],
+)
+def test_factory_materializes_internal_spin_only_contract(
+    configuration,
+    expected_configuration,
+    expected_order,
+    expected_index,
+):
+    kwargs = {}
+    if configuration is not None:
+        kwargs["spin_configuration"] = configuration
+        kwargs["spin_only_direction"] = [0, 0, 1]
+
+    group = get_spin_space_group_from_operations(
+        [_operation()],
+        spin_frame="oriented",
+        **kwargs,
+    )
+
+    assert isinstance(group, SpinSpaceGroup)
+    assert group.conf == expected_configuration
+    assert len(group.sog) == expected_order
+    assert group.index == expected_index
+    assert group.G0_num == 1
+    assert group.L0_num == 1
+
+
+def test_repository_operation_input_examples():
+    expected = {
+        identify_mn3sn: ("194.11.1.1.P", "Coplanar", 48),
+        identify_mn3sn_with_explicit_spin_only_semantics: (
+            "194.11.1.1.P",
+            "Coplanar",
+            48,
+        ),
+        identify_mn3sn_convention_cartesian: (
+            "194.11.1.1.P",
+            "Coplanar",
+            48,
+        ),
+        identify_mn3sn_magnetic_primitive_oriented: (
+            "194.11.1.1.P",
+            "Coplanar",
+            48,
+        ),
+        identify_mnte: ("194.164.1.1.L", "Collinear", 96),
+        identify_crse: ("194.149.3.3", "Noncoplanar", 216),
+    }
+
+    for factory, (index, configuration, operation_count) in expected.items():
+        group = factory()
+        assert group.index == index
+        assert group.conf == configuration
+        assert len(group.ops) == operation_count
+
+
+def test_factory_infers_collinear_axis_from_noncanonical_spin_only_generators():
+    angle = 2 * np.pi / 3
+    c3z = np.array(
+        [
+            [np.cos(angle), -np.sin(angle), 0],
+            [np.sin(angle), np.cos(angle), 0],
+            [0, 0, 1],
+        ]
+    )
+    mirror_xz = np.diag([1, -1, 1])
+
+    group = get_spin_space_group_from_operations(
+        [_operation(c3z), _operation(mirror_xz)],
+        spin_frame="oriented",
+    )
+
+    assert group.conf == "Collinear"
+    assert len(group.sog) == 4
+    assert np.allclose(np.abs(group.collinear_axis), [0, 0, 1], atol=1e-8)
+    assert group.index == "1.1.1.1.L"
+
+
+def test_factory_closes_affine_generators_and_matches_complete_operation_input():
+    inversion = _operation(IDENTITY, -IDENTITY, [0.5, 0, 0])
+    generated = get_spin_space_group_from_operations(
+        [inversion],
+        spin_frame="oriented",
+    )
+    complete = get_spin_space_group_from_operations(
+        [_operation(), inversion],
+        spin_frame="oriented",
+    )
+
+    assert len(generated.ops) == 2
+    assert generated.index == complete.index
+    assert all(
+        any(left.is_same_with(right, atol=1e-8) for right in complete.ops)
+        for left in generated.ops
+    )
+
+
+def test_factory_closes_spin_translation_generator_modulo_collinear_spin_only_group():
+    spin_translation = _operation(-IDENTITY, IDENTITY, [0.5, 0, 0])
+
+    group = get_spin_space_group_from_operations(
+        [spin_translation],
+        spin_configuration="collinear",
+        spin_only_direction=[0, 0, 1],
+        spin_frame="oriented",
+    )
+
+    assert group.conf == "Collinear"
+    assert group.index == "1.1.2.1.L"
+    assert len(group.ops) == 8
+    assert group.ik == 2
+    assert group.msg_bns_num == "1.3"
+
+
+def test_factory_accepts_serialized_operation_dicts():
+    group = get_spin_space_group_from_operations(
+        [
+            {
+                "spin_rotation": IDENTITY.tolist(),
+                "real_rotation": IDENTITY.tolist(),
+                "translation": ZERO.tolist(),
+            }
+        ],
+        spin_frame="oriented",
+    )
+
+    assert group.index == "1.1.1.1"
+
+
+@pytest.mark.parametrize("translation", ([1, 0, 0], [-1e-8, 0, 0]))
+def test_factory_rejects_translations_outside_mod_one_cell(translation):
+    with pytest.raises(ValueError, match=r"\[0, 1\)"):
+        get_spin_space_group_from_operations(
+            [_operation(translation=translation)]
+        )
+
+
+def test_factory_rejects_explicit_configuration_conflicting_with_spin_only_group():
+    spin_plane_mirror = np.diag([1, 1, -1])
+
+    with pytest.raises(ValueError, match="conflicts"):
+        get_spin_space_group_from_operations(
+            [_operation(), _operation(spin_plane_mirror)],
+            spin_configuration="collinear",
+            spin_only_direction=[0, 0, 1],
+            spin_frame="oriented",
+        )
+
+
+def test_factory_requires_direction_when_explicit_configuration_cannot_infer_it():
+    with pytest.raises(ValueError, match="spin_only_direction"):
+        get_spin_space_group_from_operations(
+            [_operation()],
+            spin_configuration="collinear",
+            spin_frame="oriented",
+        )
+
+
+def test_factory_accepts_finite_spin_rotations_in_a_nonorthogonal_basis():
+    basis = np.array(
+        [
+            [1.0, 0.5, 0.0],
+            [0.0, np.sqrt(3.0) / 2.0, 0.0],
+            [0.0, 0.0, 2.0],
+        ]
+    )
+    basis_inverse = np.linalg.inv(basis)
+    angle = 2 * np.pi / 3
+    c3_cartesian = np.array(
+        [
+            [np.cos(angle), -np.sin(angle), 0],
+            [np.sin(angle), np.cos(angle), 0],
+            [0, 0, 1],
+        ]
+    )
+    mirror_cartesian = np.diag([1, -1, 1])
+    c3_nonorthogonal = basis_inverse @ c3_cartesian @ basis
+    mirror_nonorthogonal = basis_inverse @ mirror_cartesian @ basis
+
+    group = get_spin_space_group_from_operations(
+        [_operation(c3_nonorthogonal), _operation(mirror_nonorthogonal)],
+        spin_frame="oriented",
+    )
+
+    assert group.conf == "Collinear"
+    assert group.index == "1.1.1.1.L"
+
+
+def test_factory_rejects_spin_matrices_without_finite_invariant_metric():
+    with pytest.raises(ValueError, match="determinant"):
+        get_spin_space_group_from_operations(
+            [_operation(np.diag([2, 1, 1]))],
+            spin_frame="oriented",
+        )
+
+
+def _hexagonal_frame_case():
+    lattice = np.array(
+        [
+            [2.0, 0.0, 0.0],
+            [-1.0, np.sqrt(3.0), 0.0],
+            [0.0, 0.0, 5.0],
+        ]
+    )
+    metric = lattice @ lattice.T
+    setting_to_cartesian = np.linalg.cholesky(metric).T
+    real_threefold = np.array(
+        [
+            [0.0, -1.0, 0.0],
+            [1.0, -1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    spin_threefold_cartesian = (
+        setting_to_cartesian
+        @ real_threefold
+        @ np.linalg.inv(setting_to_cartesian)
+    )
+    return lattice, metric, real_threefold, spin_threefold_cartesian
+
+
+def test_factory_cartesian_frame_matches_oriented_frame_for_generators():
+    lattice, metric, real_threefold, spin_threefold_cartesian = (
+        _hexagonal_frame_case()
+    )
+    cartesian = get_spin_space_group_from_operations(
+        [_operation(spin_threefold_cartesian, real_threefold)],
+        spin_frame="cartesian",
+        real_space_lattice=lattice,
+        real_space_metric=metric,
+    )
+    oriented = get_spin_space_group_from_operations(
+        [_operation(real_threefold, real_threefold)],
+        spin_frame="oriented",
+        real_space_metric=metric,
+    )
+
+    assert cartesian.input_spin_frame == "cartesian"
+    assert cartesian.spin_settings == "oriented"
+    assert cartesian.index == oriented.index
+    assert cartesian.msg_bns_num == oriented.msg_bns_num
+    assert len(cartesian.ops) == len(oriented.ops)
+    assert all(
+        any(left.is_same_with(right, atol=1e-8) for right in oriented.ops)
+        for left in cartesian.ops
+    )
+
+
+def test_factory_cartesian_frame_uses_default_relative_frame_from_metric():
+    _lattice, metric, real_threefold, spin_threefold_cartesian = (
+        _hexagonal_frame_case()
+    )
+    cartesian = get_spin_space_group_from_operations(
+        [_operation(spin_threefold_cartesian, real_threefold)],
+        spin_frame="cartesian",
+        real_space_metric=metric,
+    )
+    oriented = get_spin_space_group_from_operations(
+        [_operation(real_threefold, real_threefold)],
+        spin_frame="oriented",
+        real_space_metric=metric,
+    )
+
+    assert cartesian.index == oriented.index
+    assert cartesian.msg_bns_num == oriented.msg_bns_num
+
+
+def test_factory_cartesian_frame_matches_oriented_frame_for_complete_operations():
+    lattice, metric, real_threefold, spin_threefold_cartesian = (
+        _hexagonal_frame_case()
+    )
+    cartesian_generator = _operation(
+        spin_threefold_cartesian,
+        real_threefold,
+    )
+    oriented_generator = _operation(real_threefold, real_threefold)
+    cartesian_complete = [
+        _operation(),
+        cartesian_generator,
+        cartesian_generator @ cartesian_generator,
+    ]
+    oriented_complete = [
+        _operation(),
+        oriented_generator,
+        oriented_generator @ oriented_generator,
+    ]
+
+    cartesian = get_spin_space_group_from_operations(
+        cartesian_complete,
+        spin_frame="cartesian",
+        real_space_lattice=lattice,
+        real_space_metric=metric,
+    )
+    oriented = get_spin_space_group_from_operations(
+        oriented_complete,
+        spin_frame="oriented",
+        real_space_metric=metric,
+    )
+
+    assert cartesian.index == oriented.index
+    assert cartesian.msg_bns_num == oriented.msg_bns_num
+
+
+def test_factory_cartesian_frame_is_invariant_under_common_rigid_rotation():
+    lattice, metric, real_threefold, spin_threefold_cartesian = (
+        _hexagonal_frame_case()
+    )
+    angle = 0.37
+    rigid_rotation = np.array(
+        [
+            [np.cos(angle), -np.sin(angle), 0.0],
+            [np.sin(angle), np.cos(angle), 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    rotated_lattice = lattice @ rigid_rotation.T
+    rotated_spin = (
+        rigid_rotation
+        @ spin_threefold_cartesian
+        @ rigid_rotation.T
+    )
+
+    cartesian = get_spin_space_group_from_operations(
+        [_operation(rotated_spin, real_threefold)],
+        spin_frame="cartesian",
+        real_space_lattice=rotated_lattice,
+        real_space_metric=metric,
+    )
+    oriented = get_spin_space_group_from_operations(
+        [_operation(real_threefold, real_threefold)],
+        spin_frame="oriented",
+        real_space_metric=metric,
+    )
+
+    assert cartesian.index == oriented.index
+    assert cartesian.msg_bns_num == oriented.msg_bns_num
+
+
+def test_factory_cartesian_frame_handles_permuted_setting_lattice():
+    lattice = np.array(
+        [
+            [-2.0, 0.0, 0.0],
+            [0.0, 0.0, 3.0],
+            [0.0, 4.0, 0.0],
+        ]
+    )
+    metric = lattice @ lattice.T
+    setting_to_cartesian = lattice.T
+    real_twofold = np.diag([-1.0, -1.0, 1.0])
+    spin_twofold_cartesian = (
+        setting_to_cartesian
+        @ real_twofold
+        @ np.linalg.inv(setting_to_cartesian)
+    )
+
+    cartesian = get_spin_space_group_from_operations(
+        [_operation(spin_twofold_cartesian, real_twofold)],
+        spin_frame="cartesian",
+        real_space_lattice=lattice,
+        real_space_metric=metric,
+    )
+    oriented = get_spin_space_group_from_operations(
+        [_operation(real_twofold, real_twofold)],
+        spin_frame="oriented",
+        real_space_metric=metric,
+    )
+
+    assert cartesian.index == oriented.index
+    assert cartesian.msg_bns_num == oriented.msg_bns_num
+
+
+def test_factory_cartesian_frame_transforms_explicit_spin_only_direction():
+    lattice = np.diag([2.0, 3.0, 4.0])
+    metric = lattice @ lattice.T
+    cartesian = get_spin_space_group_from_operations(
+        [_operation()],
+        spin_configuration="collinear",
+        spin_only_direction=[1, 0, 0],
+        spin_frame="cartesian",
+        real_space_lattice=lattice,
+        real_space_metric=metric,
+    )
+    oriented = get_spin_space_group_from_operations(
+        [_operation()],
+        spin_configuration="collinear",
+        spin_only_direction=[1, 0, 0],
+        spin_frame="oriented",
+        real_space_metric=metric,
+    )
+
+    assert cartesian.index == oriented.index
+    assert np.allclose(cartesian.collinear_axis, oriented.collinear_axis)
+
+
+def test_factory_default_cartesian_frame_requires_real_space_geometry():
+    with pytest.raises(ValueError, match="real_space_lattice or real_space_metric"):
+        get_spin_space_group_from_operations([_operation()])
+
+
+def test_factory_defaults_to_cartesian_frame():
+    group = get_spin_space_group_from_operations(
+        [_operation()],
+        real_space_lattice=np.eye(3),
+    )
+
+    assert group.input_spin_frame == "cartesian"
+    assert group.spin_settings == "oriented"
+
+
+def test_factory_rejects_unknown_spin_frame():
+    with pytest.raises(ValueError, match="spin_frame must be one of"):
+        get_spin_space_group_from_operations(
+            [_operation()],
+            spin_frame="laboratory",
+        )
+
+
+def test_factory_rejects_inconsistent_lattice_and_metric():
+    with pytest.raises(ValueError, match="inconsistent"):
+        get_spin_space_group_from_operations(
+            [_operation()],
+            real_space_lattice=np.eye(3),
+            real_space_metric=2 * np.eye(3),
+        )
+
+
+def test_factory_roundtrips_material_operation_views_across_settings_and_frames():
+    cases = [
+        ("src/findspingroup/examples/0.200_Mn3Sn.mcif", None),
+        (
+            "src/findspingroup/examples/0.800_MnTe.mcif",
+            {
+                "configuration": "collinear",
+                "cartesian_direction": [0.5, np.sqrt(3.0) / 2.0, 0.0],
+                "oriented_direction": [1.0, 1.0, 0.0],
+            },
+        ),
+        ("src/findspingroup/examples/CoNb3S6_tripleQ.mcif", None),
+    ]
+
+    for path, spin_semantics in cases:
+        result = find_spin_group(path, components=["operation_views"])
+        cell_details = {
+            "convention": result.convention_cell_detail,
+            "magnetic_primitive": result.acc_primitive_magnetic_cell_detail,
+            "input": result.input_cell_detail,
+        }
+        for setting_key, setting_payload in result.operation_views.items():
+            setting_name, spin_frame = setting_key.rsplit("_", 1)
+            lattice = np.asarray(
+                cell_details[setting_name]["lattice"],
+                dtype=float,
+            )
+            metric = lattice @ lattice.T
+            all_operations = setting_payload["views"]["all"]["ops"]
+            generator_indices = list(
+                setting_payload["views"]["generators"]["indices"]
+            )
+            generator_indices.extend(
+                setting_payload["views"]
+                .get("spin_translations", {})
+                .get("indices", [])
+            )
+            generator_indices = list(dict.fromkeys(generator_indices))
+            generator_operations = [
+                all_operations[index - 1] for index in generator_indices
+            ]
+            kwargs = {}
+            if spin_semantics is not None:
+                kwargs = {
+                    "spin_configuration": spin_semantics["configuration"],
+                    "spin_only_direction": spin_semantics[
+                        f"{spin_frame}_direction"
+                    ],
+                }
+
+            for supplied_operations in (all_operations, generator_operations):
+                rebuilt = get_spin_space_group_from_operations(
+                    supplied_operations,
+                    spin_frame=spin_frame,
+                    real_space_lattice=lattice,
+                    real_space_metric=metric,
+                    tol=0.01,
+                    **kwargs,
+                )
+                assert rebuilt.index == result.index
+                assert rebuilt.conf == result.conf
+                assert rebuilt.msg_bns_num == result.msg_bns_number
+
+
+def test_factory_roundtrips_high_order_coplanar_operation_input():
+    result = find_spin_group(
+        "tests/testset/mcif_241130_no2186/1.0.41_RbNiCl3.mcif",
+        components=["operation_views"],
+    )
+    setting = result.operation_views["magnetic_primitive_oriented"]
+    operations = setting["views"]["all"]["ops"]
+    generator_indices = list(setting["views"]["generators"]["indices"])
+    generator_indices.extend(setting["views"]["spin_translations"]["indices"])
+    generator_indices = list(dict.fromkeys(generator_indices))
+    generators = [operations[index - 1] for index in generator_indices]
+    lattice = np.asarray(
+        result.acc_primitive_magnetic_cell_detail["lattice"],
+        dtype=float,
+    )
+
+    rebuilt = get_spin_space_group_from_operations(
+        operations,
+        spin_frame="oriented",
+        real_space_lattice=lattice,
+        tol=0.01,
+    )
+    rebuilt_from_generators = get_spin_space_group_from_operations(
+        generators,
+        spin_frame="oriented",
+        real_space_lattice=lattice,
+        tol=0.01,
+    )
+
+    assert rebuilt.index == result.index
+    assert rebuilt.conf == "Coplanar"
+    assert rebuilt.msg_bns_num == result.msg_bns_number
+    assert rebuilt_from_generators.index == result.index
+    assert rebuilt_from_generators.conf == "Coplanar"
+    assert rebuilt_from_generators.msg_bns_num == result.msg_bns_number


### PR DESCRIPTION
## Summary

- Add `get_spin_space_group_from_operations(...)` to identify an SSG from complete operations or generators.
- Support collinear, coplanar, and noncoplanar spin-only semantics.
- Support Cartesian and oriented spin-frame inputs.
- Add executable examples, API documentation, and regression tests.

## Motivation

External tools may already have spin-space-group operations but no atomic structure. Existing structure-based routes cannot directly consume this input without constructing an artificial witness crystal.

This API closes and identifies the supplied affine spin-space operations directly and returns a `SpinSpaceGroup`.

## Main changes

- Validate serialized operations and require translations reduced to `[0, 1)`.
- Accept either complete operation sets or generator subsets.
- Close finite affine operations with a configurable safety bound.
- Infer spin-only configuration and direction, or accept them explicitly.
- Normalize external collinear and coplanar semantics to FindSpinGroup's finite internal representation.
- Use Cartesian spin input by default, requiring `real_space_lattice` or `real_space_metric`.
- Retain explicit `spin_frame="oriented"` support.
- Expose operation-derived SSG index, G0/L0, ACC, k-point, point-group, and MSG analyses.
- Document that structure-derived atoms, Wyckoff data, magnetic phase, SCIF, and POSCAR are outside this API's scope.

## Risk / compatibility

This adds a new public API and does not alter existing structure-based identification routes.

The operation-only API interprets spin matrices as Cartesian by default. Callers whose matrices are already expressed in the current real-space setting basis must explicitly use:

```python
spin_frame="oriented"